### PR TITLE
Update hpmor-chapter-061.tex

### DIFF
--- a/chapters/hpmor-chapter-061.tex
+++ b/chapters/hpmor-chapter-061.tex
@@ -362,7 +362,7 @@ Then Albus shook his head in dismay, and said, “Severus, do \emph{you} compreh
 
 “And they knew about rockets, too?” Severus said dryly. “I don’t believe the other Death Eaters were so fond of Muggle Studies. It is he.”
 
-“Aye, it is he,” Albus said. “Azkaban has endured impenetrable for ages, only to fall to an ordinary Animagus potion. It is too clever and too impossible, which was ever Voldemort’s signature since the days he was known as Tom Riddle. Anyone who wished to forge that signature must needs be as cunning as Voldemort himself to do so. And there is no-one else in the world who would accidentally overestimate my wit, and leave me a message I cannot understand at all.”
+“Aye, it is he,” Albus said. “Azkaban has endured impenetrable for ages, only to fall to an ordinary Animagus potion. It is too clever and too impossible, which was ever Voldemort’s signature since the days he was known as Tom Riddle. Anyone who wished to forge that signature must be as cunning as Voldemort himself to do so. And there is no-one else in the world who would accidentally overestimate my wit, and leave me a message I cannot understand at all.”
 
 “Unless he has gauged you exactly,” Severus said tonelessly, “in which case all that is just what he intended you to think.”
 


### PR DESCRIPTION
This PR removes what seems like a leftover word from a possible previous rewording, perhaps "needs to be" was meant to be changed to "must be", and the "needs" was left