### PR TITLE
add switch for parsel font variants

### DIFF
--- a/layout/hp-markup.tex
+++ b/layout/hp-markup.tex
@@ -23,7 +23,19 @@
   \StrSubstitute{\parsselstring}{ß}{sss}[\parssselstring]%
 }
 % N.B. Other commands, such as \emph, cannot be used inside \parsel
-\newcommand{\parsel}[1]{\parselify{\fontspec[ExternalLocation]{Parseltongue.ttf}#1}{\ptsansi\parssselstring}}
+%
+% parsel
+% old version of parsel
+\newcommand{\parsela}[1]{\parselify{#1}%
+{\ptsansi\parssselstring}}
+%
+% new FR version of parsel by yeKcim
+% note: Other commands, such as \emph, cannot be used inside \parsel
+\newcommand{\parselb}[1]{\parselify{\fontspec[ExternalLocation]{Parseltongue.ttf}#1}%
+{\ptsansi\parssselstring}}
+%
+% select one of above
+\newcommand{\parsel}[1]{\parsela{#1}}
 
 % \spell macro
 \newcommand{\spell}[1]{{\Star}\emph{#1}{\Star}}


### PR DESCRIPTION
I find the new Parseltongue.ttf font very hard to read and even disturbing the read flow, so I prefer not to use it, despite it being an awesome font. Hence, I suggest to keep this great font in the repo, in order to make it available via a feature switch. 

at @rrthomas and @yeKcim: what do you think? Anyone able to convert the feature switch in better latex coding that my proposal?

new parsel font was introduced in https://github.com/rrthomas/hpmor/commit/c4dcafb7ef34f15b2324af37f8f198f98685c245 