### PR TITLE
remove unnecessary slur against the Roma community

### DIFF
--- a/chapters/hpmor-chapter-015.tex
+++ b/chapters/hpmor-chapter-015.tex
@@ -20,7 +20,7 @@ There were hundreds of fantasy novels scattered around the Verres household. Har
 
 And the fury had entered his blood, he had held out his wand in a hand that trembled with hate and said in cold tones “\emph{Frigideiro!}” and absolutely nothing had happened.
 
-Harry had been \emph{gypped}. He wanted to write someone and demand a \emph{refund} on his dark side which clearly \emph{ought} to have irresistible magical power but had turned out to be \emph{defective}.
+Harry had been \emph{robbed}. He wanted to write someone and demand a \emph{refund} on his dark side which clearly \emph{ought} to have irresistible magical power but had turned out to be \emph{defective}.
 
 “\emph{Frigideiro!}” said Hermione again from the desk next to him. Her water was solid ice and there were white crystals forming on the rim of her glass. She seemed to be totally intent on her own work and not at all conscious of the other students staring at her with hateful eyes, which was either (a)~dangerously oblivious of her or (b)~a perfectly honed performance rising to the level of fine art.
 


### PR DESCRIPTION
Using the word `gypped` (deriving from `Gypsy`) to mean "robbed" is a hurtful slur against the Roma community, which unfortunately still suffers violence for who they are to this day. This change removes the slur without changing the meaning at all.