### PR TITLE
Fix McGonagall's whiteboard in ebooks

### DIFF
--- a/chapters/hpmor-chapter-015.tex
+++ b/chapters/hpmor-chapter-015.tex
@@ -70,17 +70,7 @@ Several students gulped.
 
 Professor McGonagall stood up and moved over to the wall behind her desk, which held a polished wooden board. “There are many reasons why Transfiguration is dangerous, but one reason stands above all the rest.” She produced a short quill with a thick end and used it to sketch letters in red, which she then underlined, using the same marker, in blue:
 
-\begin{center}
-  \newsavebox{\hpbox}%
-  \fontspec[ExternalLocation,Color=AA0000]{Florante}
-  \savebox{\hpbox}{\MakeUppercase{Transfiguration is not permanent!}}
-  \vspace{0.5ex}
-  \usebox{\hpbox}
-  \settowidth{\versewidth}{\usebox{\hpbox}}
-  \vskip -1ex
-  \fontspec[ExternalLocation,Color=2020FF]{ArchitectsDaughter}
-  \resizebox{\versewidth}{.6ex}{\rotatebox{90}{I}}
-\end{center}
+\McGonagallWhiteBoard{Transfiguration is not permanent!}
 
 “Transfiguration is not permanent!” said Professor McGonagall. “Transfiguration is not permanent! Transfiguration is not permanent! Mr~Potter, suppose a student Transfigured a block of wood into a cup of water, and you drank it. What do you imagine might happen to you when the Transfiguration wore off?” There was a pause. “Excuse me, I should not have asked that of you, Mr~Potter, I forgot that you are blessed with an unusually pessimistic imagination—”
 

--- a/layout/hp-markup.tex
+++ b/layout/hp-markup.tex
@@ -46,6 +46,21 @@
 \newcommand{\authorsnotefootnotemark}{}
 \newcommand{\authorsnotetext}[1]{}
 
+% McGonagall's board
+\newcommand{\McGonagallWhiteBoard}[1]{%
+  \begin{center}
+    \newsavebox{\hpbox}%
+    \fontspec[ExternalLocation,Color=AA0000]{Florante}
+    \savebox{\hpbox}{\MakeUppercase{#1}}
+    \vspace{0.5ex}
+    \usebox{\hpbox}
+    \settowidth{\versewidth}{\usebox{\hpbox}}
+    \vskip -1ex
+    \fontspec[ExternalLocation,Color=2020FF]{ArchitectsDaughter}
+    \resizebox{\versewidth}{.6ex}{\rotatebox{90}{I}}
+  \end{center}%
+}
+
 
 % Newspaper headlines
 

--- a/scripts/ebook/hpmor-ebook.tex
+++ b/scripts/ebook/hpmor-ebook.tex
@@ -13,7 +13,7 @@
 
 \newcommand{\writtenNoteA}[1]{\par\textcolor{writtenNote}{#1}}
 \renewcommand{\parsel}[1]{\textcolor{parsel}{#1}}
-\renewcommand{\McGonagallWhiteBoard}[1]{\textcolor{McGonagallWhiteBoard}{#1}}
+\renewcommand{\McGonagallWhiteBoard}[1]{\textcolor{McGonagallWhiteBoard}{\par#1}}
 \renewcommand{\headline}[1]{\begin{center}\textcolor{headline}{#1}\end{center}}
 \renewcommand{\inlineheadline}[1]{\textcolor{headline}{#1}}
 

--- a/scripts/ebook/hpmor-ebook.tex
+++ b/scripts/ebook/hpmor-ebook.tex
@@ -13,7 +13,7 @@
 
 \newcommand{\writtenNoteA}[1]{\par\textcolor{writtenNote}{#1}}
 \renewcommand{\parsel}[1]{\textcolor{parsel}{#1}}
-\renewcommand{\McGonagallWhiteBoard}[1]{\begin{center}\underline{\MakeUppercase{#1}}\end{center}}
+\renewcommand{\McGonagallWhiteBoard}[1]{\textcolor{McGonagallWhiteBoard}{#1}}
 \renewcommand{\headline}[1]{\begin{center}\textcolor{headline}{#1}\end{center}}
 \renewcommand{\inlineheadline}[1]{\textcolor{headline}{#1}}
 

--- a/scripts/ebook/hpmor-ebook.tex
+++ b/scripts/ebook/hpmor-ebook.tex
@@ -13,7 +13,7 @@
 
 \newcommand{\writtenNoteA}[1]{\par\textcolor{writtenNote}{#1}}
 \renewcommand{\parsel}[1]{\textcolor{parsel}{#1}}
-\renewcommand{\McGonagallWhiteBoard}[1]{\begin{center}\textcolor{McGonagallWhiteBoard}{#1}\end{center}}
+\renewcommand{\McGonagallWhiteBoard}[1]{\begin{center}\underline{\MakeUppercase{#1}}\end{center}}
 \renewcommand{\headline}[1]{\begin{center}\textcolor{headline}{#1}\end{center}}
 \renewcommand{\inlineheadline}[1]{\textcolor{headline}{#1}}
 

--- a/scripts/ebook/html.css
+++ b/scripts/ebook/html.css
@@ -102,8 +102,10 @@ span.writtenNote {
 	margin-left: 1em;
 }
 
-span.McGonagallWhiteBoard {
+div.McGonagallWhiteBoard {
 	color: #cc3333;
+	text-align: center;
+	text-transform: uppercase;
 	text-decoration: underline;
 	text-decoration-color: #3333cc;
 	/* text-decoration-thickness: 1px; */


### PR DESCRIPTION
Currently, it renders as `<p>-1ex</p>`, which was somewhat confusing the first time I encountered it.

I think the `\begin{center}` environment does not actually work in the current epub, but that is a different problem.