### PR TITLE
ebook text-align: justify

### DIFF
--- a/scripts/ebook/html.css
+++ b/scripts/ebook/html.css
@@ -1,5 +1,10 @@
 /* start html.css */
 
+p {
+	text-align: justify;
+	line-height: 1.25;
+}
+
 em {
 	font-style: italic;
 }
@@ -102,7 +107,7 @@ span.writtenNote {
 	margin-left: 1em;
 }
 
-div.McGonagallWhiteBoard {
+div.McGonagallWhiteBoard p {
 	color: #cc3333;
 	text-align: center;
 	text-transform: uppercase;


### PR DESCRIPTION
in the ebook, I suggest adding `text-align: justify;`:

before:
<img width="445" alt="image" src="https://github.com/rrthomas/hpmor/assets/59419684/275ccaf6-0c20-41c6-8ec9-8fcb887cd184">

after:
<img width="445" alt="image" src="https://github.com/rrthomas/hpmor/assets/59419684/81554f69-7661-436c-a6ff-a214baa2c974">
