### PR TITLE
ebook fix: remove stray markup from the text

### DIFF
--- a/scripts/ebook/step_3.py
+++ b/scripts/ebook/step_3.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     cont = re.sub(r"\\clearpage(\{\}|)\n?", "", cont)
 
     # \vskip 1\baselineskip plus .5\textheight minus 1\baselineskip
-    cont = re.sub(r"\\vskip .*?\\baselineskip", "", cont)
+    cont = re.sub(r"\\vskip .*\\baselineskip", "", cont)
 
     # remove \settowidth{\versewidth}... \begin{verse}[\versewidth]
     cont = re.sub(


### PR DESCRIPTION
Hello! Thanks for putting so much work into formatting HPMOR nicely. I'm re-reading it in ebook format in Apple Books right now and really enjoying it.

I noticed some stray markup in chapter 23:

<img width="610" alt="Screenshot 2024-08-26 at 7 53 19 PM" src="https://github.com/user-attachments/assets/0eb2d97d-c4c0-482a-8873-e2bfd12161ff">

`"plus .5minus 1"` clearly doesn't belong there. I looked into it and you can see the source of this markup in the original latex:

https://github.com/rrthomas/hpmor/blob/9ecaeba555c45578b8ce2c8f5df1605bb386fc76/chapters/hpmor-chapter-023.tex#L125-L140

The problem happens in `step_3.py`, which tries to remove this markup completely:

https://github.com/rrthomas/hpmor/blob/9ecaeba555c45578b8ce2c8f5df1605bb386fc76/scripts/ebook/step_3.py#L53-L54

But because the regex uses a minimal quantifier instead of a greedy one, it only matches `"\vskip 1\baselineskip"`, stopping at the first `"\baselineskip"` instead of the one at the end of the line. This leaves the errant bit of markup in the text:

    plus .5\textheight minus 1\baselineskip

Which, because it does not start with a backslash, ends up inserted into the content.

The fix is simple: remove the `'?'`, turning the `".*"` into a greedy match instead of a minimal match. This matches to the end of the last `"\baselineskip"`, completely removing this bit of markup from the text as intended.

---

Note: I only made this change because of the issue in chapter 23, but it also comes up in a few other places. Here's the full diff of tmp/hpmor-epub-3-flatten-mod.tex. I think these are all good changes, but I'm not sure. I'm not that familiar with the markup and I haven't figured out how to fully render the ebook yet to check how it looks:

```diff
# diff new/hpmor-epub-3-flatten-mod.tex old/hpmor-epub-3-flatten-mod.tex
164c164
< \newenvironment{writtenNote}{\fontspec[ExternalLocation]{Graphe_Alpha_alt.ttf}\scriptsize \renewcommand{\emph}{\uline}}\itshape }
---
> \newenvironment{writtenNote}{\fontspec[ExternalLocation]{Graphe_Alpha_alt.ttf}\scriptsize \renewcommand{\emph}{\uline} plus .1\baselineskip minus .1\baselineskip \begin{adjustwidth}{\parindent}{\parindent}\par\setlength{\parindent}{0pt}\setlength{\parskip}{\baselineskip}\itshape }
166c166
< \end{adjustwidth} }
---
> \end{adjustwidth} plus 1\baselineskip minus 1\baselineskip }
9255c9255
<
---
>  plus .5\textheight minus 1\baselineskip
9268c9268
<
---
>  plus .5\textheight minus 1\baselineskip
9287c9287
<
---
>  plus .5\textheight minus 1\baselineskip
9306c9306
<
---
>  plus .5\textheight minus 1\baselineskip
23525c23525
< \newcommand{\OmakeIVspecialsection}[2][1.5]{\vspace*{2\baselineskip plus 1\baselineskip minus 1\baselineskip}\noindent\hfill\scalebox{#1}{#2}\hfill\mbox{} \@afterindentfalse\@afterheading
---
> \newcommand{\OmakeIVspecialsection}[2][1.5]{\vspace*{2\baselineskip plus 1\baselineskip minus 1\baselineskip}\noindent\hfill\scalebox{#1}{#2}\hfill\mbox{} plus 1\baselineskip \@afterindentfalse\@afterheading
```