### PR TITLE
Update make.yml workflow to know which repo it's being run in

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Download previous hpmor.html
         run: |
-          wget --quiet https://github.com/rrthomas/hpmor/releases/tag/WorkInProgress/hpmor.html -O hpmor-prev.html
+          wget --quiet https://github.com/${{ github.repository }}/releases/tag/WorkInProgress/hpmor.html -O hpmor-prev.html
 
       - name: Make PDFs
         run: sh scripts/make_pdfs.sh > /dev/null


### PR DESCRIPTION
This removes the hard-coded `rrthomas/hpmor` repository slug from the workflow and uses the [`${{ <context> }}` syntax][github-context].

![image](https://github.com/user-attachments/assets/669e3385-0af9-4be0-ba57-6570264e7a64)

[github-context]: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context

This change doesn't affect anything within https://github.com/rrthomas/hpmor, but it means that my fork won't try to access the releases of this one. Feel free to ignore this if you don't think it's necessary :)