### PR TITLE
Update latexmkrc to not specify the branch being built

### DIFF
--- a/latexmkrc
+++ b/latexmkrc
@@ -23,7 +23,7 @@ if (-d $hooks_dir) {
       my $mode = (stat($hook))[2];
       chmod $mode | 0111, $hook;
     }
-    system "git", "checkout", "main"; # Generate .git/gitHeadInfo.gin
+    system "git", "checkout"; # Generate .git/gitHeadInfo.gin
   }
 }
 


### PR DESCRIPTION
This allows the make.yml workflow to run on a non-main branch, which in-turn allows testing a feature branch.