### PR TITLE
Revert commit 60007ff

### DIFF
--- a/chapters/hpmor-chapter-012.tex
+++ b/chapters/hpmor-chapter-012.tex
@@ -66,7 +66,7 @@ Pause.
 
 Harry applauded Zabini too, ignoring the odd looks he was getting from everyone including Zabini.
 
-No other name was called out after that, and Harry realised that “Zabini, Blaise” did sound close to the end of the alphabet. Great, so now the \emph{only} Slytherin he’d applauded was Zabini…Oh well.
+No other name was called out after that, and Harry realised that “Zabini, Blaise” did sound close to the end of the alphabet. Great, so now he’d \emph{only} applauded Zabini…Oh well.
 
 Dumbledore got up again and began heading towards the podium. Apparently they were about to be treated to a speech—
 

--- a/chapters/hpmor-chapter-012.tex
+++ b/chapters/hpmor-chapter-012.tex
@@ -66,7 +66,7 @@ Pause.
 
 Harry applauded Zabini, ignoring the odd looks he was getting from everyone including Zabini.
 
-No other name was called out after that, and Harry realised that “Zabini, Blaise” did sound close to the end of the alphabet. Great, so now the \emph{only} Slytherin he’d  applauded was Zabini…Oh well.
+No other name was called out after that, and Harry realised that “Zabini, Blaise” did sound close to the end of the alphabet. Great, so now he’d \emph{only} applauded Zabini…Oh well.
 
 Dumbledore got up again and began heading towards the podium. Apparently they were about to be treated to a speech—
 

--- a/chapters/hpmor-chapter-012.tex
+++ b/chapters/hpmor-chapter-012.tex
@@ -52,7 +52,7 @@ Harry was sorta guessing that wasn’t supposed to be part of the official Sorti
 
 “GRYFFINDOR!”
 
-Ron Weasley got a \emph{lot} of applause, and not just from the Gryffindors. Apparently the Weasley family was widely liked around here. Harry, after a moment, smiled and started applauding along with the others.
+Ron Weasley got a \emph{lot} of applause, and not just from the Gryffindors. Apparently the Weasley family was widely liked around here. Harry, after a moment, smiled and started cheering along with the others.
 
 Then again, there was no time like today to turn back from the Dark Side.
 
@@ -64,7 +64,7 @@ Pause.
 
 “SLYTHERIN!” shouted the hat.
 
-Harry applauded Zabini too, ignoring the odd looks he was getting from everyone including Zabini.
+Harry applauded Zabini, ignoring the odd looks he was getting from everyone including Zabini.
 
 No other name was called out after that, and Harry realised that “Zabini, Blaise” did sound close to the end of the alphabet. Great, so now he’d \emph{only} applauded Zabini…Oh well.
 


### PR DESCRIPTION
The rewording doesn't read well to me, so for consideration, this is my suggestion to resolve #176. Instead of changing the wording, this just changes the word "applauding" to "cheering" and that makes the inconsistency go away with much less changes to the prose.