### PR TITLE
Fix link to download WIP html file

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Download previous hpmor.html
         run: |
-          wget --quiet https://github.com/${{ github.repository }}/releases/tag/WorkInProgress/hpmor.html -O hpmor-prev.html
+          wget --quiet https://github.com/${{ github.repository }}/releases/download/WorkInProgress/hpmor.html -O hpmor-prev.html
 
       - name: Make PDFs
         run: sh scripts/make_pdfs.sh > /dev/null


### PR DESCRIPTION
The previous link was downloading the HTML of the release page in GitHub, not the asset... 🤦

![image](https://github.com/user-attachments/assets/75d492dc-f479-4319-9784-e30b92c79f3f)
