### PR TITLE
Fix failure when nothing has changed in the HTML diff 

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Compare to previous hpmor.html
         run: |
-          diff -u hpmor-prev.html hpmor.html > hpmor-html-diff.log || :
+          diff -u -s hpmor-prev.html hpmor.html > hpmor-html-diff.log || :
           rm hpmor-prev.html
 
       - name: Test ls after


### PR DESCRIPTION
See for example https://github.com/rrthomas/hpmor/actions/runs/12793679166

This failed because the `hpmor-html-diff.log` file was 0 bytes (i.e. the diff was empty due to no textual changes).

![image](https://github.com/user-attachments/assets/c4563972-a051-4b3a-bb68-a4b02eb05884)

The fix is to tell the `diff` command to output "files are identical" in this case so that the log reflects this.