### PR TITLE
Speed up build by tuning apt and dpkg

### DIFF
--- a/.github/workflows/check-and-make.yml
+++ b/.github/workflows/check-and-make.yml
@@ -95,17 +95,7 @@ jobs:
           python-version: "3.12"
           cache: "pip"
 
-      # https://github.com/abbbi/github-actions-tune/blob/master/speedup.sh
-      - run: sudo sed -i 's/yes/no/g' '/etc/initramfs-tools/update-initramfs.conf'
-      - run: sudo rm -f /var/lib/man-db/auto-update
-      - run: sudo sed '/fontconfig/d' -i '/var/lib/dpkg/triggers/File'
-      - run: sudo sed '/install-info/d' -i '/var/lib/dpkg/triggers/File'
-      - run: sudo sed '/mime/d' -i '/var/lib/dpkg/triggers/File'
-      - run: sudo sed '/hicolor-icon-theme/d' -i '/var/lib/dpkg/triggers/File'
-      - run: echo "force-unsafe-io" | sudo tee -a /etc/dpkg/dpkg.cfg.d/force-unsafe-io
-      - run: echo -e '#!/bin/sh\nexec eatmydata /usr/bin/dpkg $@' | sudo tee /usr/local/bin/dpkg && sudo chmod +x /usr/local/bin/dpkg
-      - run: echo -e '#!/bin/sh\nexec eatmydata /usr/bin/apt $@' | sudo tee /usr/local/bin/apt && sudo chmod +x /usr/local/bin/apt
-      - run: echo -e '#!/bin/sh\nexec eatmydata /usr/bin/apt-get $@' | sudo tee /usr/local/bin/apt-get && sudo chmod +x /usr/local/bin/apt-get
+      - uses: abbbi/github-actions-tune@v1
 
       - name: Install requirements (apt and python)
         run: sh scripts/install_requirements.sh > /dev/null

--- a/.github/workflows/check-and-make.yml
+++ b/.github/workflows/check-and-make.yml
@@ -95,7 +95,8 @@ jobs:
           python-version: "3.12"
           cache: "pip"
 
-      - uses: abbbi/github-actions-tune@v1
+      - name: Speed up apt-get steps
+        uses: abbbi/github-actions-tune@v1
 
       - name: Install requirements (apt and python)
         run: sh scripts/install_requirements.sh > /dev/null

--- a/.github/workflows/check-and-make.yml
+++ b/.github/workflows/check-and-make.yml
@@ -95,6 +95,18 @@ jobs:
           python-version: "3.12"
           cache: "pip"
 
+      # https://github.com/abbbi/github-actions-tune/blob/master/speedup.sh
+      - run: sudo sed -i 's/yes/no/g' '/etc/initramfs-tools/update-initramfs.conf'
+      - run: sudo rm -f /var/lib/man-db/auto-update
+      - run: sudo sed '/fontconfig/d' -i '/var/lib/dpkg/triggers/File'
+      - run: sudo sed '/install-info/d' -i '/var/lib/dpkg/triggers/File'
+      - run: sudo sed '/mime/d' -i '/var/lib/dpkg/triggers/File'
+      - run: sudo sed '/hicolor-icon-theme/d' -i '/var/lib/dpkg/triggers/File'
+      - run: echo "force-unsafe-io" | sudo tee -a /etc/dpkg/dpkg.cfg.d/force-unsafe-io
+      - run: echo -e '#!/bin/sh\nexec eatmydata /usr/bin/dpkg $@' | sudo tee /usr/local/bin/dpkg && sudo chmod +x /usr/local/bin/dpkg
+      - run: echo -e '#!/bin/sh\nexec eatmydata /usr/bin/apt $@' | sudo tee /usr/local/bin/apt && sudo chmod +x /usr/local/bin/apt
+      - run: echo -e '#!/bin/sh\nexec eatmydata /usr/bin/apt-get $@' | sudo tee /usr/local/bin/apt-get && sudo chmod +x /usr/local/bin/apt-get
+
       - name: Install requirements (apt and python)
         run: sh scripts/install_requirements.sh > /dev/null
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -61,7 +61,8 @@ jobs:
       - name: Check pre-commit tests
         uses: pre-commit/action@v3.0.1
 
-      - uses: abbbi/github-actions-tune@v1
+      - name: Speed up apt-get steps
+        uses: abbbi/github-actions-tune@v1
 
       - name: Install requirements
         run: sh scripts/install_requirements.sh > /dev/null

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -61,6 +61,18 @@ jobs:
       - name: Check pre-commit tests
         uses: pre-commit/action@v3.0.1
 
+      # https://github.com/abbbi/github-actions-tune/blob/master/speedup.sh
+      - run: sudo sed -i 's/yes/no/g' '/etc/initramfs-tools/update-initramfs.conf'
+      - run: sudo rm -f /var/lib/man-db/auto-update
+      - run: sudo sed '/fontconfig/d' -i '/var/lib/dpkg/triggers/File'
+      - run: sudo sed '/install-info/d' -i '/var/lib/dpkg/triggers/File'
+      - run: sudo sed '/mime/d' -i '/var/lib/dpkg/triggers/File'
+      - run: sudo sed '/hicolor-icon-theme/d' -i '/var/lib/dpkg/triggers/File'
+      - run: echo "force-unsafe-io" | sudo tee -a /etc/dpkg/dpkg.cfg.d/force-unsafe-io
+      - run: echo -e '#!/bin/sh\nexec eatmydata /usr/bin/dpkg $@' | sudo tee /usr/local/bin/dpkg && sudo chmod +x /usr/local/bin/dpkg
+      - run: echo -e '#!/bin/sh\nexec eatmydata /usr/bin/apt $@' | sudo tee /usr/local/bin/apt && sudo chmod +x /usr/local/bin/apt
+      - run: echo -e '#!/bin/sh\nexec eatmydata /usr/bin/apt-get $@' | sudo tee /usr/local/bin/apt-get && sudo chmod +x /usr/local/bin/apt-get
+
       - name: Install requirements
         run: sh scripts/install_requirements.sh > /dev/null
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -61,17 +61,7 @@ jobs:
       - name: Check pre-commit tests
         uses: pre-commit/action@v3.0.1
 
-      # https://github.com/abbbi/github-actions-tune/blob/master/speedup.sh
-      - run: sudo sed -i 's/yes/no/g' '/etc/initramfs-tools/update-initramfs.conf'
-      - run: sudo rm -f /var/lib/man-db/auto-update
-      - run: sudo sed '/fontconfig/d' -i '/var/lib/dpkg/triggers/File'
-      - run: sudo sed '/install-info/d' -i '/var/lib/dpkg/triggers/File'
-      - run: sudo sed '/mime/d' -i '/var/lib/dpkg/triggers/File'
-      - run: sudo sed '/hicolor-icon-theme/d' -i '/var/lib/dpkg/triggers/File'
-      - run: echo "force-unsafe-io" | sudo tee -a /etc/dpkg/dpkg.cfg.d/force-unsafe-io
-      - run: echo -e '#!/bin/sh\nexec eatmydata /usr/bin/dpkg $@' | sudo tee /usr/local/bin/dpkg && sudo chmod +x /usr/local/bin/dpkg
-      - run: echo -e '#!/bin/sh\nexec eatmydata /usr/bin/apt $@' | sudo tee /usr/local/bin/apt && sudo chmod +x /usr/local/bin/apt
-      - run: echo -e '#!/bin/sh\nexec eatmydata /usr/bin/apt-get $@' | sudo tee /usr/local/bin/apt-get && sudo chmod +x /usr/local/bin/apt-get
+      - uses: abbbi/github-actions-tune@v1
 
       - name: Install requirements
         run: sh scripts/install_requirements.sh > /dev/null


### PR DESCRIPTION
I've adapted the [recommendations][abbbi-actions] of @abbbi's [`speedup.sh`][abbbi-speedup] script to significantly reduce the run time of the various `apt-get install` steps in `scripts/install_requirements.sh`.

Compare a run without this change to one with this setup, note that the additional changes here all run in under a second:

![image](https://github.com/user-attachments/assets/ecdcd37c-f072-4579-9afd-157b3a18f88f)
![image](https://github.com/user-attachments/assets/6f032391-4022-4b38-b4de-066aea7e5b37)

This is a reduction of about 3-4 minutes, which I find very helpful in my infinite (im)patience 😂

[abbbi-actions]: https://abbbi.github.io/actions
[abbbi-speedup]: https://github.com/abbbi/github-actions-tune/blob/master/speedup.sh